### PR TITLE
MB-7: adding exact matches and dice units

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -117,13 +117,28 @@ const regexExceptions = [
       [/5’6"/g, "1.70 m."],
       [/2’11"/g, "0.90 m."],
       [/4’9"/g, "1.50 m."],
-      [/4’10"/g, "1.55 m."]
+      [/4’10"/g, "1.55 m."],
+      [/\(12 × 3\)/g, "(12 × 3 / 2)"]
+    ],
+    []
+  ],
+  [
+    pa_dice_unit,
+    [
+      ["lb\\.", " / 2 kg."],
+      ["pounds", " / 2 kilograms"],
+      ["inches", " × 2.5 centimeters"],
+      ["in\\.", " × 2.5 cm."],
+      ["miles", " × 1.5 kilometers"],
+      ["ounces", " × 30 grams"],
+      ["gallons", " × 3.5 liters"],
+      [/^((?:[+×])\(?\d+d\d+)\)?$/g, " × 2.5 cm."]
     ],
     []
   ]
 ];
 
-function changeToMeters_One(element) {
+function ch_to_meters_one(element) {
   if (element.classList.contains("ddbc-combat-attack__range-value-long")) {
     element.textContent = "(" + (parseFloat(element.textContent.match(/\d+/)) * 30) / 100 + ")";
   } else {
@@ -131,7 +146,7 @@ function changeToMeters_One(element) {
   }
 }
 
-function changeToMeters() {
+function ch_to_meters() {
   var distancesNumber, distancesUnit, numberOfDistances;
 
   if (document.querySelector(".ddbc-distance-number")) {
@@ -142,7 +157,7 @@ function changeToMeters() {
     for (var i = 0; i < numberOfDistances; i++) {
       if (distancesUnit[i].textContent == 'ft.') {
         if (distancesNumber[i].textContent != "--") {
-          changeToMeters_One(distancesNumber[i]);
+          ch_to_meters_one(distancesNumber[i]);
         }
         distancesUnit[i].textContent = 'm.';
       }
@@ -155,16 +170,16 @@ function changeToMeters() {
 
     for (var i = 0; i < numberOfDistances; i++) {
       if (!distancesNumber[i].classList.contains("converted")) {
-        changeToMeters_One(distancesNumber[i]);
-        changeToMeters_One(distancesUnit[i]);
+        ch_to_meters_one(distancesNumber[i]);
+        ch_to_meters_one(distancesUnit[i]);
         distancesNumber[i].classList.add("converted");
       }
     }
   }
-  changeItemRange();
+  ch_item_range();
 }
 
-function changeItemRange() {
+function ch_item_range() {
   if (document.querySelector(".ddbc-note-components__component")) {
     var regexItem = /\((\d+)\/(\d+)\)/g;
     var itemRange = document.querySelectorAll(".ddbc-note-components__component");
@@ -187,19 +202,19 @@ function changeItemRange() {
   }
 }
 
-function changeToKilograms_One(elementNumber, elementUnit) {
+function ch_to_kg_one(elementNumber, elementUnit) {
   elementNumber.textContent = (parseFloat(elementNumber.textContent) * 1000) / 2000;
   elementUnit.textContent = "kg.";
 }
 
-function changeToKilograms() {
+function ch_to_kg() {
 
   if (document.querySelector(".ddbc-weight-number")) {
     var weightNumber = document.querySelectorAll(".ddbc-weight-number__number");
     var weightUnit = document.querySelectorAll(".ddbc-weight-number__label");
     weightNumber.forEach((element, index) => {
       if (weightUnit[index].textContent == 'lb.') {
-        changeToKilograms_One(element, weightUnit[index]);
+        ch_to_kg_one(element, weightUnit[index]);
       }
     });
   }
@@ -223,7 +238,7 @@ function changeToKilograms() {
   }
 }
 
-function changeInText(divList) {
+function ch_in_text(divList) {
   var currDiv;
   for (let i = 0; i < divList.length; i++) {
     currDiv = document.querySelectorAll(divList[i]);
@@ -352,12 +367,16 @@ function pa_dice_unit(element, regex, rate) {
   var text = element.innerHTML;
   var matches, unit, reg;
   regex.forEach((regexElement) => {
-    reg = regexElement[0];
+    if (typeof regexElement[0] === "object")
+      reg = regexElement[0];
+    else
+      reg = new RegExp("((?:[+×])?\\(?\\d+d\\d+)\\)?\\s*" + regexElement[0], "g");
     matches = [...text.matchAll(reg)];
     if (matches.length != 0) {
       matches.forEach((match) => {
         unit = regexElement[1];
-        text = text.replace(match[0], unit);
+        match[1] = match[1].replace("(", "");
+        text = text.replace(match[0], match[1] + unit);
       });
       // Sanitizing the text before adding it to the page
       element.innerHTML = DOMPurify.sanitize(text);
@@ -365,26 +384,26 @@ function pa_dice_unit(element, regex, rate) {
   });
 }
 
-function changeInMonsterPage() {
+function ch_in_monster() {
   const monsterPageDivs = [
     ".mon-stat-block p",
     ".mon-details__description-block p",
     '.mon-stat-block span[class$="-data"]'
   ];
-  changeInText(monsterPageDivs);
+  ch_in_text(monsterPageDivs);
 }
 
-function changeInEncounterPage() {
+function ch_in_encounter() {
   const encounterPageDivs = [
     ".mon-stat-block p",
     ".mon-details__description-block p",
     '.mon-stat-block span[class$="-data"]',
     '.line-item__value'
   ];
-  changeInText(encounterPageDivs);
+  ch_in_text(encounterPageDivs);
 }
 
-function changeInOtherPage() {
+function ch_in_other() {
   const otherPageDivs = [
     ".ddb-statblock-item-value",
     ".more-info-content p",
@@ -393,10 +412,10 @@ function changeInOtherPage() {
     ".p-article-content li",
     ".p-article-content td"
   ];
-  changeInText(otherPageDivs);
+  ch_in_text(otherPageDivs);
 }
 
-function changeInCharacterPage() {
+function ch_in_character() {
   const characterPageDivs = [
     ".ct-senses__summary",
     ".jsx-parser p",
@@ -408,12 +427,12 @@ function changeInCharacterPage() {
     ".ct-preferences-pane__field-description",
     ".ddbc-property-list__property-content"
   ];
-  changeToMeters();
-  changeToKilograms();
-  changeInText(characterPageDivs);
+  ch_to_meters();
+  ch_to_kg();
+  ch_in_text(characterPageDivs);
 }
 
-function observeWhenReady() {
+function observe_when_ready() {
   var observedNode = document.querySelector("body");
   if (!observedNode) {
     window.setTimeout(addObserverIfDesiredNodeAvailable, 500);
@@ -421,31 +440,31 @@ function observeWhenReady() {
   }
   var url = window.location.href;
   if (url.match(/characters\//g)) {
-    const observer = new MutationObserver(changeInCharacterPage);
+    const observer = new MutationObserver(ch_in_character);
     observer.observe(observedNode, { childList: true, subtree: true });
   } else if (url.match(/monsters\//g)) {
-    changeInMonsterPage();
+    ch_in_monster();
   } else if (url.match(/(?:encounters|combat-tracker)\//g)) {
-    const observer = new MutationObserver(changeInEncounterPage);
+    const observer = new MutationObserver(ch_in_encounter);
     observer.observe(observedNode, { childList: true, subtree: true });
   } else {
-    changeInOtherPage();
+    ch_in_other();
   }
 
 }
 
-function loadPreferencesAndRun(result) {
+function load_and_run(result) {
   if (result.state == "disabled") {
     console.log("Metric Beyond is disabled");
   }
   else {
-    observeWhenReady();
+    observe_when_ready();
   }
 }
 
-function onError(error) {
+function on_error(error) {
   console.log(`Error: ${error}`);
 }
 
 const getting = currentBrowser.storage.local.get("state");
-getting.then(loadPreferencesAndRun, onError);
+getting.then(load_and_run, on_error);

--- a/src/manifest_chrome.json
+++ b/src/manifest_chrome.json
@@ -3,7 +3,7 @@
 
     "name": "Metric Beyond",
     "description": "Bring the metric unit system to D&D Beyond!",
-    "version": "1.9.0",
+    "version": "1.9.1",
 
     "icons": {
         "256": "images/Chrome_Metric_Beyond_256.png",

--- a/src/manifest_firefox.json
+++ b/src/manifest_firefox.json
@@ -3,7 +3,7 @@
 
     "name": "Metric Beyond",
     "description": "Bring the metric unit system to D&D Beyond!",
-    "version": "1.9.0",
+    "version": "1.9.1",
 
     "icons": {
         "256": "images/Metric_Beyond_256.png",


### PR DESCRIPTION
The only I found to fix split units is simply to convert them with exact matches. That's because WotC didn't use their regular conversion rate for those. Sometimes the regular conversion rate works sometimes they decided to add an extra 5 cm.

I'm now working on conversion for dice units.